### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/frontend_web/lib/ocr-service.ts
+++ b/frontend_web/lib/ocr-service.ts
@@ -90,12 +90,12 @@ export class OCRService {
     // Try each API key for this chunk
     for (const apiKey of this.apiKeys) {
       try {
-        console.log(`Processing pages ${pages.join(',')} with key: ${apiKey.substring(0, 5)}...`);
+        console.log(`Processing pages ${pages.join(',')} with OCR service...`);
         const text = await this.sendOCRRequest(buffer, filename, apiKey, pages);
         return text;
       } catch (error: any) {
         lastError = error;
-        console.log(`OCR key ${apiKey.substring(0, 5)} failed for pages ${pages.join(',')}:`, error.message);
+        console.log(`OCR attempt failed for pages ${pages.join(',')}:`, error.message);
         
         // If it's a rate limit, wait longer
         if (error.message.includes('403') || error.message.includes('rate')) {


### PR DESCRIPTION
Potential fix for [https://github.com/saad2134/UPISensei/security/code-scanning/2](https://github.com/saad2134/UPISensei/security/code-scanning/2)

To fix the problem, remove or sufficiently sanitize any sensitive data (here, the API key) from log messages. The operational goal of the log line is to identify which attempt failed for which pages; this can be preserved by logging only non-sensitive information (e.g., the attempt index or pages) without exposing the key itself.

The best fix without changing functionality is to stop logging any portion of `apiKey`. Instead, log an attempt counter or a generic placeholder. Since we must not assume other parts of the code, and we only see this method, a simple and safe change is: replace the message so that it does not interpolate `apiKey` at all, for example: ``console.log(`OCR attempt failed for pages ${pages.join(',')}:`, error.message);``. This keeps information about which pages failed and why, which is what is operationally valuable, while eliminating the sensitive content. Concretely, in `frontend_web/lib/ocr-service.ts`, within `processPDFChunk`, change the log on line 98 to remove `apiKey.substring(0, 5)` entirely. No new imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
