### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/frontend_web/lib/ocr-service.ts
+++ b/frontend_web/lib/ocr-service.ts
@@ -88,14 +88,15 @@ export class OCRService {
     let lastError: Error | null = null;
     
     // Try each API key for this chunk
-    for (const apiKey of this.apiKeys) {
+    for (let keyIndex = 0; keyIndex < this.apiKeys.length; keyIndex++) {
+      const apiKey = this.apiKeys[keyIndex];
       try {
-        console.log(`Processing pages ${pages.join(',')} with key: ${apiKey.substring(0, 5)}...`);
+        console.log(`Processing pages ${pages.join(',')} with key index: ${keyIndex}`);
         const text = await this.sendOCRRequest(buffer, filename, apiKey, pages);
         return text;
       } catch (error: any) {
         lastError = error;
-        console.log(`OCR key ${apiKey.substring(0, 5)} failed for pages ${pages.join(',')}:`, error.message);
+        console.log(`OCR key index ${keyIndex} failed for pages ${pages.join(',')}:`, error.message);
         
         // If it's a rate limit, wait longer
         if (error.message.includes('403') || error.message.includes('rate')) {


### PR DESCRIPTION
Potential fix for [https://github.com/saad2134/UPISensei/security/code-scanning/1](https://github.com/saad2134/UPISensei/security/code-scanning/1)

In general, to fix this type of problem, remove sensitive data (API keys, tokens, passwords, secrets) from log messages altogether, or replace them with non‑sensitive identifiers that still allow debugging (such as an index, a hash that cannot be reversed, or a static label). Logging whether a particular attempt succeeded or failed is fine; including the secret is not.

For this specific code, the best fix without changing existing functionality is: stop logging the key contents (`apiKey.substring(0, 5)`) and instead log a non‑sensitive identifier for the key, such as its index in `this.apiKeys` or a constant label like `"key #<n>"`. We can achieve this by changing the `for` loop in `processPDFChunk` to iterate with an index (`for (let i = 0; i < this.apiKeys.length; i++)`) and then using that index in log messages. This preserves all behavior except the leaking of key material. The two affected log lines are line 93 and line 98 in `frontend_web/lib/ocr-service.ts`. No new imports or methods are necessary; we only adjust the loop structure and the log message strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
