### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/frontend_web/app/scan-payment/page.tsx
+++ b/frontend_web/app/scan-payment/page.tsx
@@ -466,7 +466,7 @@ export default function ScanPaymentPage() {
     localStorage.setItem('scan_transactions', JSON.stringify(transactions))
 
     if (isAndroid()) {
-      const upiDeepLink = `upi://pay?pa=${scannedData.pa}&pn=${encodeURIComponent(scannedData.pn)}&am=${amount}&tn=${encodeURIComponent(scannedData.tn || `Payment for ${categoryNames[selectedCategory]}`)}&cu=INR`
+      const upiDeepLink = `upi://pay?pa=${scannedData.pa}&pn=${encodeURIComponent(scannedData.pn)}&am=${encodeURIComponent(amount)}&tn=${encodeURIComponent(scannedData.tn || `Payment for ${categoryNames[selectedCategory]}`)}&cu=INR`
       
       console.log('Redirecting to UPI app:', upiDeepLink)
       stopCamera()


### PR DESCRIPTION
Potential fix for [https://github.com/saad2134/UPISensei/security/code-scanning/3](https://github.com/saad2134/UPISensei/security/code-scanning/3)

General fix: Never insert raw DOM text into URLs or HTML; apply appropriate encoding (e.g., `encodeURIComponent`) before concatenation. For URL query parameters, each parameter value should be URL-encoded. This prevents special characters from breaking the structure or being interpreted in unintended ways.

Best fix here: Update the construction of `upiDeepLink` so that `amount` is URL-encoded before being embedded, consistent with how `pn` and `tn` are handled. This keeps functionality intact but ensures any characters from the DOM input cannot alter the URL structure. Since `amount` logically should be numeric, encoding it is safe and behaviorally equivalent (digits are unchanged; problematic characters become percent-encoded).

Specific change: In `frontend_web/app/scan-payment/page.tsx`, on line 469, wrap `amount` in `encodeURIComponent(...)` when building `upiDeepLink`. No new imports are needed; `encodeURIComponent` is a standard global. No further code changes are required because the UPI apps will receive the correct parameter value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
